### PR TITLE
Group all configurations of each target into one job

### DIFF
--- a/.github/workflows/answer-tests.yml
+++ b/.github/workflows/answer-tests.yml
@@ -24,7 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         TARGET: ${{ fromJson(needs.setup-matrix.outputs.targets) }}
-        BUILD_CONFIG: ${{ fromJson(needs.setup-matrix.outputs.build-configs) }}
     container: ${{ needs.docker-build.outputs.image }}
     defaults:
       run:
@@ -35,17 +34,43 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Build targets
-        run: |
-          if [[ ${{ matrix.BUILD_CONFIG.stdlib }} == libc++ ]]; then
-            export USE_LIBCXX=TRUE
-          fi
-          ${{ matrix.BUILD_CONFIG.compiler }} --version
-          make CXX=${{ matrix.BUILD_CONFIG.compiler }} build/release/${{ matrix.TARGET.name }}
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Run answer tests
+      - name: Run answer tests (clang++)
         timeout-minutes: 2
         run: |
-          # mark git checkout as safe
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          export CXX=clang++ USE_LIBCXX=FALSE
+          echo '::group::make output'
+          $CXX --version
+          make --silent clean
+          make build/release/${{ matrix.TARGET.name }}
+          echo '::endgroup::'
+
+          ./run_answer_tests.sh ${{ matrix.TARGET.name }}
+
+      - name: Run answer tests (g++)
+        timeout-minutes: 2
+        if: always()
+        run: |
+          export CXX=g++ USE_LIBCXX=FALSE
+          echo '::group::make output'
+          $CXX --version
+          make --silent clean
+          make build/release/${{ matrix.TARGET.name }}
+          echo '::endgroup::'
+
+          ./run_answer_tests.sh ${{ matrix.TARGET.name }}
+
+      - name: Run answer tests (clang++-17, libc++)
+        timeout-minutes: 2
+        if: always()
+        run: |
+          export CXX=clang++-17 USE_LIBCXX=TRUE
+          echo '::group::make output'
+          $CXX --version
+          make --silent clean
+          make build/release/${{ matrix.TARGET.name }}
+          echo '::endgroup::'
+
           ./run_answer_tests.sh ${{ matrix.TARGET.name }}

--- a/.github/workflows/gen_matrix.py
+++ b/.github/workflows/gen_matrix.py
@@ -128,11 +128,6 @@ class Matrix:
         elif mode == "answer":
             target_pat = re.compile("day")
         self.targets: set[Target] = set()
-        self.build_configs = [
-            BuildConfig(compiler="clang++"),
-            BuildConfig(compiler="g++"),
-            BuildConfig(compiler="clang++-17", stdlib="libc++"),
-        ]
 
         all_targets: list[Target] = []
         for base_dir in find_base_dirs():
@@ -167,22 +162,14 @@ class Matrix:
 
     def write_combinations(self, output_file: str) -> None:
         target_dicts = []
-        config_dicts = []
         if self.targets:
             print("\ntargets:")
             for target in sorted(self.targets):
                 target_dicts.append(target.to_dict())
                 print(f"  {target_dicts[-1]}")
-            print("\nbuild configurations:")
-            for config in self.build_configs:
-                config_dicts.append(config.to_dict())
-                print(f"  {config_dicts[-1]}")
         with open(output_file, "a") as f:
             f.write("matrix-targets=")
             json.dump(target_dicts, f, indent=None, separators=(",", ":"))
-            f.write("\n")
-            f.write("matrix-build-configs=")
-            json.dump(config_dicts, f, indent=None, separators=(",", ":"))
             f.write("\n")
 
 

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -9,8 +9,6 @@ on:
     outputs:
       targets:
         value: ${{ jobs.setup-matrix.outputs.targets }}
-      build-configs:
-        value: ${{ jobs.setup-matrix.outputs.build-configs }}
 
 jobs:
   setup-matrix:
@@ -34,4 +32,3 @@ jobs:
 
     outputs:
       targets: ${{ steps.setup-matrix-combinations.outputs.matrix-targets }}
-      build-configs: ${{ steps.setup-matrix-combinations.outputs.matrix-build-configs }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -24,7 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         TARGET: ${{ fromJson(needs.setup-matrix.outputs.targets) }}
-        BUILD_CONFIG: ${{ fromJson(needs.setup-matrix.outputs.build-configs) }}
     container: ${{ needs.docker-build.outputs.image }}
     defaults:
       run:
@@ -35,10 +34,25 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Build targets
+      - name: Build target (clang++)
         run: |
-          if [[ ${{ matrix.BUILD_CONFIG.stdlib }} == libc++ ]]; then
-            export USE_LIBCXX=TRUE
-          fi
-          ${{ matrix.BUILD_CONFIG.compiler }} --version
-          make -j2 CXX=${{ matrix.BUILD_CONFIG.compiler }} DISABLE_SANITIZERS=TRUE build/release/${{ matrix.TARGET.name }} build/debug/${{ matrix.TARGET.name }} build/fast/${{ matrix.TARGET.name }}
+          export CXX=clang++ USE_LIBCXX=FALSE
+          $CXX --version
+          make --silent clean
+          make -j4 DISABLE_SANITIZERS=TRUE build/release/${{ matrix.TARGET.name }} build/debug/${{ matrix.TARGET.name }} build/fast/${{ matrix.TARGET.name }}
+
+      - name: Build target (g++)
+        if: always()
+        run: |
+          export CXX=g++ USE_LIBCXX=FALSE
+          $CXX --version
+          make --silent clean
+          make -j4 DISABLE_SANITIZERS=TRUE build/release/${{ matrix.TARGET.name }} build/debug/${{ matrix.TARGET.name }} build/fast/${{ matrix.TARGET.name }}
+
+      - name: Build target (clang++-17, libc++)
+        if: always()
+        run: |
+          export CXX=clang++-17 USE_LIBCXX=TRUE
+          $CXX --version
+          make --silent clean
+          make -j4 DISABLE_SANITIZERS=TRUE build/release/${{ matrix.TARGET.name }} build/debug/${{ matrix.TARGET.name }} build/fast/${{ matrix.TARGET.name }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         TARGET: ${{ fromJson(needs.setup-matrix.outputs.targets) }}
-        BUILD_CONFIG: ${{ fromJson(needs.setup-matrix.outputs.build-configs) }}
     container: ${{ needs.docker-build.outputs.image }}
     defaults:
       run:
@@ -35,13 +34,37 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Build test
+      - name: Run unit tests (clang++)
         run: |
-          if [[ ${{ matrix.BUILD_CONFIG.stdlib }} == libc++ ]]; then
-            export USE_LIBCXX=TRUE
-          fi
-          ${{ matrix.BUILD_CONFIG.compiler }} --version
-          make CXX=${{ matrix.BUILD_CONFIG.compiler }} build/debug/${{ matrix.TARGET.name }}
+          export CXX=clang++ USE_LIBCXX=FALSE
+          echo '::group::make output'
+          $CXX --version
+          make --silent clean
+          make build/debug/${{ matrix.TARGET.name }}
+          echo '::endgroup::'
 
-      - name: Run test
-        run: make CXX=${{ matrix.BUILD_CONFIG.compiler }} ${{ matrix.TARGET.name }}
+          make ${{ matrix.TARGET.name }}
+
+      - name: Run unit tests (g++)
+        if: always()
+        run: |
+          export CXX=g++ USE_LIBCXX=FALSE
+          echo '::group::make output'
+          $CXX --version
+          make --silent clean
+          make build/debug/${{ matrix.TARGET.name }}
+          echo '::endgroup::'
+
+          make ${{ matrix.TARGET.name }}
+
+      - name: Run unit tests (clang++-17, libc++)
+        if: always()
+        run: |
+          export CXX=clang++-17 USE_LIBCXX=TRUE
+          echo '::group::make output'
+          $CXX --version
+          make --silent clean
+          make build/debug/${{ matrix.TARGET.name }}
+          echo '::endgroup::'
+
+          make ${{ matrix.TARGET.name }}


### PR DESCRIPTION
Most of the time in each job is currently spent downloading the container, and the overall run time is limited by the total number of active jobs that GitHub allows.